### PR TITLE
Have Sinatra listen on all available interfaces

### DIFF
--- a/librb/interface.rb
+++ b/librb/interface.rb
@@ -3,9 +3,11 @@ require "json"
 
 module Interface
   class Application < Sinatra::Base
+    set :bind, "0.0.0.0"
+
     @@host = nil
 
-    def self.set_host(value) 
+    def self.set_host(value)
       @@host = value
     end
 


### PR DESCRIPTION
When setting up Rules inside a Docker container, Sinatra needs to `set :bind, "0.0.0.0"`, so it listens on all available interfaces (vs just the local machine).

See: http://www.sinatrarb.com/configuration.html#bind---server-hostname-or-ip-address