### PR TITLE
Return server object from run function

### DIFF
--- a/libjs/durableEngine.js
+++ b/libjs/durableEngine.js
@@ -1554,7 +1554,7 @@ exports = module.exports = durableEngine = function () {
                 });
             });
 
-            that.listen(port, function () {
+            return that.listen(port, function () {
                 console.log('Listening on ' + port);
             });    
         };


### PR DESCRIPTION
Return express server object from `run` function so that calling code can interact directly with the server.