### PR TITLE
Fix memory leak

### DIFF
--- a/src/rules/net.c
+++ b/src/rules/net.c
@@ -2909,6 +2909,7 @@ unsigned int startNonBlockingBatch(void *rulesBinding,
         free(commands[i]);
     }
 
+    sdsfree(reContext->obuf);
     reContext->obuf = newbuf;
     int wdone = 0;
     do {
@@ -2985,6 +2986,7 @@ unsigned int executeBatchWithReply(void *rulesBinding,
         free(commands[i]);
     }
 
+    sdsfree(reContext->obuf);
     reContext->obuf = newbuf;
     redisReply *reply;
     for (unsigned int i = 0; i < replyCount; ++i) {


### PR DESCRIPTION
an sdsFree call is required to free the empty string used from a previous command transfer, because sdsnewlen or sdsempty allocate one char ('\0') + the control header at least (event when the sds string is empty)