### PR TITLE
Allow access to exception tracebacks too with messages strings.

### DIFF
--- a/libpy/durable/engine.py
+++ b/libpy/durable/engine.py
@@ -335,7 +335,9 @@ class Promise(object):
             try:
                 self._func(c) 
             except BaseException as error:
-                c.s.exception = 'exception caught {0}'.format(str(error))
+                t, v, tb = sys.exc_info()
+                c.s.exception = 'exception caught {0}, traceback {1}'.format(
+                    str(error), traceback.format_tb(tb))
             except:
                 c.s.exception = 'unknown exception'
                
@@ -364,7 +366,9 @@ class Promise(object):
                     self._timer.daemon = True     
                     self._timer.start()
             except BaseException as error:
-                c.s.exception = 'exception caught {0}'.format(str(error))
+                t, v, tb = sys.exc_info()
+                c.s.exception = 'exception caught {0}, traceback {1}'.format(
+                    str(error), traceback.format_tb(tb))
                 complete(None)
             except:
                 c.s.exception = 'unknown exception'


### PR DESCRIPTION
See: https://github.com/jruizgit/rules/issues/199