### PR TITLE
Fix buffer overrun caused by large number of states

### DIFF
--- a/src/rules/state.c
+++ b/src/rules/state.c
@@ -796,6 +796,9 @@ unsigned int ensureStateNode(void *tree,
             sidHash, 
             nodeOffset);
 
+        if (rulesetTree->statePool.count > MAX_STATE_INDEX_LENGTH) {
+            return ERR_OUT_OF_MEMORY;
+        }
         rulesetTree->reverseStateIndex[rulesetTree->statePool.count - 1] = nodeOffset;
         stateNode *node = STATE_NODE(tree, nodeOffset); 
         node->offset = nodeOffset;


### PR DESCRIPTION
This case has been raised when increasing the number of states. Also I am not sure about the error code. 