### PR TITLE
Syncing propertyMatch with match flag

### DIFF
--- a/src/rules/events.c
+++ b/src/rules/events.c
@@ -1490,24 +1490,27 @@ static unsigned int handleAplhaArray(ruleset *tree,
                             if (hashNode->value.a.expression.operator == OP_IALL || hashNode->value.a.expression.operator == OP_IANY) {
                                 // handleAplhaArray finds a valid path, thus use propertyMatch
                                 CHECK_RESULT(handleAplhaArray(tree, 
-                                                              &jo,
-                                                              currentProperty, 
-                                                              &hashNode->value.a,
-                                                              propertyMatch));
+                                            &jo,
+                                            currentProperty, 
+                                            &hashNode->value.a,
+                                            &match));
                             } else {
                                 CHECK_RESULT(isAlphaMatch(tree,
-                                                          &hashNode->value.a,
-                                                          &jo,
-                                                          &match));
+                                            &hashNode->value.a,
+                                            &jo,
+                                            &match));
+                            }
 
-                                if (match) {
-                                    if (top == MAX_STACK_SIZE) {
-                                        return ERR_MAX_STACK_SIZE;
-                                    }
-
-                                    stack[top] = &hashNode->value.a; 
-                                    ++top;
+                            if (match) {
+                                *propertyMatch = 1;
+                                if (top == MAX_STACK_SIZE) {
+                                    return ERR_MAX_STACK_SIZE;
                                 }
+
+                                stack[top] = &hashNode->value.a; 
+                                ++top;
+                            } else {
+                                *propertyMatch = 0;
                             }
                         }
                     }               


### PR DESCRIPTION
This is a tentative fix for #189. The idea is to align propertyMatch flag with match flag. I am still not fluent with this part of code, so maybe I am missing an important point, if so please provide some guidance.

The PR has been tested against the following code snippet.

```
'use strict';
var d = require('./libjs/durable.js');

d.ruleset('test', function() {
	whenAll: m.array1.anyItem(item.field == 8 && item.array2.anyItem(item.field21 == 2) )
	run: console.log("ok", JSON.stringify(m))
});

d.post('test',{array1: [{array2 : [{field21 : 2}], field : 8}]});
d.post('test',{array1: [{field : 8, array2 : [{field21 : 2}]}]});
d.post('test',{array1: [{array2 : [{field21 : 2}], field : 7}]});
d.post('test',{array1: [{field : 7, array2 : [{field21 : 2}]}]});

```