### PR TITLE
fix mac build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,10 @@ from os import path
 from os import environ
 from sys import platform
 
-if (platform == 'win32'):
+if platform == 'win32':
   environ['CFLAGS'] = '-std=c99 -D_GNU_SOURCE -_WIN32'
+elif platform == 'darwin':
+    environ['CFLAGS'] = '-std=c99 -D_GNU_SOURCE -fcommon'
 else:
   environ['CFLAGS'] = '-std=c99 -D_GNU_SOURCE'
 


### PR DESCRIPTION
Based on the thread [here](https://github.com/libpd/libpd/issues/143#issuecomment-240187256) which discusses a similar build issue as described in issue #277, I propose the following change to setup.py, which appears to fix the compilation issue.

It would be great if @jsciame could test and confirm by running `pip install git+https://github.com/jasonrig/rules.git@fix_mac_build#egg=durable_rules` to install my fork+branch.