### PR TITLE
fix memory overrun

### DIFF
--- a/src/rules/rete.h
+++ b/src/rules/rete.h
@@ -144,7 +144,7 @@ typedef struct ruleset {
     unsigned int regexStateMachineOffset;
     
     pool statePool;
-    unsigned int stateIndex[MAX_STATE_INDEX_LENGTH];
+    unsigned int stateIndex[MAX_STATE_INDEX_LENGTH * 2];
     unsigned int reverseStateIndex[MAX_STATE_INDEX_LENGTH];
     unsigned int currentStateIndex;
 


### PR DESCRIPTION
align array declaration with https://github.com/hea-lab/rules/blob/master/src/rules/rete.c#L1894