### PR TITLE
output logs via logging module, instead of print

### DIFF
--- a/libpy/durable/__init__.py
+++ b/libpy/durable/__init__.py
@@ -1,6 +1,3 @@
+import logging
 
-
-
-
-
-
+logger = logging.getLogger(__name__)

--- a/libpy/durable/engine.py
+++ b/libpy/durable/engine.py
@@ -461,7 +461,7 @@ class Ruleset(object):
                         durable_rules_engine.abandon_action(self._handle, c._handle)
                         complete(error, None)
                     except:
-                        logging.error('unknown exception type {0}, value {1}, traceback {2}'.format(t, str(v), traceback.format_tb(tb)))
+                        logging.exception('unknown exception type %s, value %s, traceback %s', t, str(v), traceback.format_tb(tb))
                         durable_rules_engine.abandon_action(self._handle, c._handle)
                         complete('unknown error', None)
 

--- a/libpy/durable/engine.py
+++ b/libpy/durable/engine.py
@@ -899,7 +899,7 @@ class Host(object):
                 try: 
                     ruleset.dispatch()
                 except BaseException as e:
-                    logging.error('Error {0}'.format(str(e)))
+                    logging.exception('Error dispatching ruleset')
 
                 timeout = 0
                 if (index == (len(self._ruleset_list) -1)):

--- a/libpy/durable/engine.py
+++ b/libpy/durable/engine.py
@@ -9,6 +9,7 @@ import datetime
 import os
 import sys
 import traceback
+import logging
 
 def _unix_now():
     dt = datetime.datetime.now()
@@ -456,11 +457,11 @@ class Ruleset(object):
                                     
                     except BaseException as error:
                         t, v, tb = sys.exc_info()
-                        print('base exception type {0}, value {1}, traceback {2}'.format(t, str(v), traceback.format_tb(tb)))
+                        logging.error('base exception type {0}, value {1}, traceback {2}'.format(t, str(v), traceback.format_tb(tb)))
                         durable_rules_engine.abandon_action(self._handle, c._handle)
                         complete(error, None)
                     except:
-                        print('unknown exception type {0}, value {1}, traceback {2}'.format(t, str(v), traceback.format_tb(tb)))
+                        logging.error('unknown exception type {0}, value {1}, traceback {2}'.format(t, str(v), traceback.format_tb(tb)))
                         durable_rules_engine.abandon_action(self._handle, c._handle)
                         complete('unknown error', None)
 
@@ -898,7 +899,7 @@ class Host(object):
                 try: 
                     ruleset.dispatch()
                 except BaseException as e:
-                    print('Error {0}'.format(str(e)))
+                    logging.error('Error {0}'.format(str(e)))
 
                 timeout = 0
                 if (index == (len(self._ruleset_list) -1)):
@@ -918,7 +919,7 @@ class Host(object):
                 try: 
                     ruleset.dispatch_timers()
                 except BaseException as e:
-                    print('Error {0}'.format(str(e)))
+                    logging.error('Error {0}'.format(str(e)))
 
                 timeout = 0
                 if (index == (len(self._ruleset_list) -1)):

--- a/libpy/durable/engine.py
+++ b/libpy/durable/engine.py
@@ -9,7 +9,8 @@ import datetime
 import os
 import sys
 import traceback
-import logging
+
+from . import logger
 
 def _unix_now():
     dt = datetime.datetime.now()
@@ -457,11 +458,11 @@ class Ruleset(object):
                                     
                     except BaseException as error:
                         t, v, tb = sys.exc_info()
-                        logging.exception('base exception type %s, value %s, traceback %s', t, str(v), traceback.format_tb(tb))
+                        logger.exception('base exception type %s, value %s, traceback %s', t, str(v), traceback.format_tb(tb))
                         durable_rules_engine.abandon_action(self._handle, c._handle)
                         complete(error, None)
                     except:
-                        logging.exception('unknown exception type %s, value %s, traceback %s', t, str(v), traceback.format_tb(tb))
+                        logger.exception('unknown exception type %s, value %s, traceback %s', t, str(v), traceback.format_tb(tb))
                         durable_rules_engine.abandon_action(self._handle, c._handle)
                         complete('unknown error', None)
 
@@ -899,7 +900,7 @@ class Host(object):
                 try: 
                     ruleset.dispatch()
                 except BaseException as e:
-                    logging.exception('Error dispatching ruleset')
+                    logger.exception('Error dispatching ruleset')
 
                 timeout = 0
                 if (index == (len(self._ruleset_list) -1)):
@@ -919,7 +920,7 @@ class Host(object):
                 try: 
                     ruleset.dispatch_timers()
                 except BaseException as e:
-                    logging.error('Error {0}'.format(str(e)))
+                    logger.exception('Error dispatching timers')
 
                 timeout = 0
                 if (index == (len(self._ruleset_list) -1)):

--- a/libpy/durable/engine.py
+++ b/libpy/durable/engine.py
@@ -457,7 +457,7 @@ class Ruleset(object):
                                     
                     except BaseException as error:
                         t, v, tb = sys.exc_info()
-                        logging.error('base exception type {0}, value {1}, traceback {2}'.format(t, str(v), traceback.format_tb(tb)))
+                        logging.exception('base exception type %s, value %s, traceback %s', t, str(v), traceback.format_tb(tb))
                         durable_rules_engine.abandon_action(self._handle, c._handle)
                         complete(error, None)
                     except:

--- a/libpy/durable/lang.py
+++ b/libpy/durable/lang.py
@@ -1,3 +1,5 @@
+import logging
+
 from . import engine
 
 class avalue(object):
@@ -201,7 +203,7 @@ class value(object):
             if self._type == '$s':
                 raise Exception('s not allowed as rvalue')
 
-            print('defining {0}, {1}'.format(self._type, self._left))
+            logging.debug('defining {0}, {1}'.format(self._type, self._left))
             new_definition = {self._type: self._left}
         else:
             new_definition = {self._op: {self._left: right_definition}}

--- a/libpy/durable/lang.py
+++ b/libpy/durable/lang.py
@@ -202,7 +202,7 @@ class value(object):
             if self._type == '$s':
                 raise Exception('s not allowed as rvalue')
 
-            logging.debug('defining %s, %s', self._type, self._left)
+            logger.debug('defining %s, %s', self._type, self._left)
             new_definition = {self._type: self._left}
         else:
             new_definition = {self._op: {self._left: right_definition}}

--- a/libpy/durable/lang.py
+++ b/libpy/durable/lang.py
@@ -1,6 +1,5 @@
-import logging
+from . import engine, logger
 
-from . import engine
 
 class avalue(object):
 
@@ -203,7 +202,7 @@ class value(object):
             if self._type == '$s':
                 raise Exception('s not allowed as rvalue')
 
-            logging.debug('defining {0}, {1}'.format(self._type, self._left))
+            logging.debug('defining %s, %s', self._type, self._left)
             new_definition = {self._type: self._left}
         else:
             new_definition = {self._op: {self._left: right_definition}}


### PR DESCRIPTION
This is a resubmit of PR #315, removing all the spacing fixes. I will submit a separate PR, which brings the `libpy.durable` python module up to PEP8 compliance.

# Problem
The Python module for the rules engine currently outputs all logs via stdout with the standard print function. It is typically a good idea to utilize the logging module, so that the deployed application can sort and hide printed information that won't be necessary to log. This also assists log analytics tools, such as splunk, in identifying errors.

# Solution
I have replaced all print statements inside of the libpy/durable module with calls to the appropriate logging method.