### PR TITLE
Fix compilation issue with gcc 10.1.0

### DIFF
--- a/src/rules/rete.c
+++ b/src/rules/rete.c
@@ -59,6 +59,7 @@
 } while(0)
 
 
+handleEntry handleEntries[MAX_HANDLES];
 unsigned int firstEmptyEntry = 1;
 unsigned int lastEmptyEntry = MAX_HANDLES -1;
 char entriesInitialized = 0;

--- a/src/rules/rules.h
+++ b/src/rules/rules.h
@@ -66,7 +66,7 @@ typedef struct handleEntry {
     unsigned int nextEmptyEntry;
 } handleEntry;
 
-handleEntry handleEntries[MAX_HANDLES];
+extern handleEntry handleEntries[MAX_HANDLES];
 extern unsigned int firstEmptyEntry;
 extern unsigned int lastEmptyEntry;
 extern char entriesInitialized;


### PR DESCRIPTION
* Add `extern` to `handleEntries` in rules.h
* Add declaration of `handleEntries` to rete.c

Hey I had some issues when trying to install from pip and when building from source. My guess it has something to do with later versions of gcc (though I could be wrong). It seemed fine when I installed within a dockerized project (using gcc 8.3.0). My machine is running gcc 10.1.0.

OS: Arch Linux x86_64
Kernel: 5.6.15-arch1-1

I tested with python running a few examples from the docs.

<details>
<summary>Excerpt from pip installation error</summary>

```
Installing collected packages: durable-rules
    Running setup.py install for durable-rules ... error
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-u7jntlvc/durable-rules/setup.py'"'"'; __file__='"'"'/tmp/pip-install-u7jntlvc/durable-rules/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-z0xxpdru/install-record.txt --single-version-externally-managed --user --prefix= --compile --install-headers /home/dan0000/.local/include/python3.8/durable-rules
         cwd: /tmp/pip-install-u7jntlvc/durable-rules/
    Complete output (54 lines):
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.8
    creating build/lib.linux-x86_64-3.8/durable
    copying libpy/durable/engine.py -> build/lib.linux-x86_64-3.8/durable
    copying libpy/durable/__init__.py -> build/lib.linux-x86_64-3.8/durable
    copying libpy/durable/lang.py -> build/lib.linux-x86_64-3.8/durable
    running build_clib
    building 'durable_rules_engine_py' library
    creating build/temp.linux-x86_64-3.8
    creating build/temp.linux-x86_64-3.8/src
    creating build/temp.linux-x86_64-3.8/src/rules
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -std=c99 -D_GNU_SOURCE -fPIC -c src/rules/json.c -o build/temp.linux-x86_64-3.8/src/rules/json.o
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -std=c99 -D_GNU_SOURCE -fPIC -c src/rules/rete.c -o build/temp.linux-x86_64-3.8/src/rules/rete.o
    In function ‘storeString’,
        inlined from ‘createRuleset’ at src/rules/rete.c:1906:5:
    src/rules/rete.c:92:5: warning: ‘strncpy’ output truncated before terminating nul copying 1 byte from a string of the same length [-Wstringop-truncation]
       92 |     strncpy(tree->stringPool + *stringOffset, newString, length);
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In function ‘storeString’,
        inlined from ‘createRuleset’ at src/rules/rete.c:1901:5:
    src/rules/rete.c:92:5: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
       92 |     strncpy(tree->stringPool + *stringOffset, newString, length);
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from src/rules/rete.c:6:
    src/rules/rete.c: In function ‘createRuleset’:
    src/rules/rete.c:1904:30: note: length computed here
     1904 |                              strlen(name)));
          |                              ^~~~~~~~~~~~
    src/rules/rules.h:75:27: note: in definition of macro ‘CHECK_RESULT’
       75 |     unsigned int result = func; \
          |                           ^~~~
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -std=c99 -D_GNU_SOURCE -fPIC -c src/rules/state.c -o build/temp.linux-x86_64-3.8/src/rules/state.o
    src/rules/state.c: In function ‘fixupIds’:
    src/rules/state.c:1337:9: warning: ‘strncpy’ output truncated before terminating nul copying 1 byte from a string of the same length [-Wstringop-truncation]
     1337 |         strncpy(jo->sidBuffer, "0", 1);
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -std=c99 -D_GNU_SOURCE -fPIC -c src/rules/events.c -o build/temp.linux-x86_64-3.8/src/rules/events.o
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -std=c99 -D_GNU_SOURCE -fPIC -c src/rules/regex.c -o build/temp.linux-x86_64-3.8/src/rules/regex.o
    ar rcs build/temp.linux-x86_64-3.8/libdurable_rules_engine_py.a build/temp.linux-x86_64-3.8/src/rules/json.o build/temp.linux-x86_64-3.8/src/rules/rete.o build/temp.linux-x86_64-3.8/src/rules/state.o build/temp.linux-x86_64-3.8/src/rules/events.o build/temp.linux-x86_64-3.8/src/rules/regex.o
    running build_ext
    building 'durable_rules_engine' extension
    creating build/temp.linux-x86_64-3.8/src/rulespy
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fno-semantic-interposition -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -std=c99 -D_GNU_SOURCE -fPIC -Isrc/rules -I/usr/include/python3.8 -c src/rulespy/rules.c -o build/temp.linux-x86_64-3.8/src/rulespy/rules.o
    gcc -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -fno-semantic-interposition -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -std=c99 -D_GNU_SOURCE build/temp.linux-x86_64-3.8/src/rulespy/rules.o -L/usr/lib -Lbuild/temp.linux-x86_64-3.8 -ldurable_rules_engine_py -o build/lib.linux-x86_64-3.8/durable_rules_engine.cpython-38-x86_64-linux-gnu.so
    /usr/bin/ld: build/temp.linux-x86_64-3.8/libdurable_rules_engine_py.a(rete.o):/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: multiple definition of `handleEntries'; build/temp.linux-x86_64-3.8/src/rulespy/rules.o:/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: first defined here
    /usr/bin/ld: build/temp.linux-x86_64-3.8/libdurable_rules_engine_py.a(state.o):/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: multiple definition of `handleEntries'; build/temp.linux-x86_64-3.8/src/rulespy/rules.o:/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: first defined here
    /usr/bin/ld: build/temp.linux-x86_64-3.8/libdurable_rules_engine_py.a(events.o):/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: multiple definition of `handleEntries'; build/temp.linux-x86_64-3.8/src/rulespy/rules.o:/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: first defined here
    /usr/bin/ld: build/temp.linux-x86_64-3.8/libdurable_rules_engine_py.a(regex.o):/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: multiple definition of `handleEntries'; build/temp.linux-x86_64-3.8/src/rulespy/rules.o:/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: first defined here
    /usr/bin/ld: build/temp.linux-x86_64-3.8/libdurable_rules_engine_py.a(json.o):/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: multiple definition of `handleEntries'; build/temp.linux-x86_64-3.8/src/rulespy/rules.o:/tmp/pip-install-u7jntlvc/durable-rules/src/rules/rules.h:69: first defined here
    collect2: error: ld returned 1 exit status
    error: command 'gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /usr/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-u7jntlvc/durable-rules/setup.py'"'"'; __file__='"'"'/tmp/pip-install-u7jntlvc/durable-rules/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-z0xxpdru/install-record.txt --single-version-externally-managed --user --prefix= --compile --install-headers /home/dan0000/.local/include/python3.8/durable-rules Check the logs for full command output.
```
</details>