### PR TITLE
Add extra argument to timer thread lambdas

### DIFF
--- a/librb/engine.rb
+++ b/librb/engine.rb
@@ -1083,7 +1083,7 @@ module Engine
 
       timer = Timers::Group.new
 
-      thread_lambda = -> c {
+      thread_lambda = -> c, _t {
         if @ruleset_list.empty?
           timer.after 0.5, &thread_lambda
         else
@@ -1116,7 +1116,7 @@ module Engine
 
       timer = Timers::Group.new
 
-      thread_lambda = -> c {
+      thread_lambda = -> c, _t {
         if @ruleset_list.empty?
           timer.after 0.5, &thread_lambda
         else


### PR DESCRIPTION
The Timer gem [uses two arguments](https://github.com/socketry/timers/blob/master/lib/timers/timer.rb#L104). The lambdas originally accepted 1.